### PR TITLE
Improve PostgreSQL system detection for better resiliency

### DIFF
--- a/src/utils/system.ts
+++ b/src/utils/system.ts
@@ -61,59 +61,153 @@ export function checkRequirement(requirement: SystemRequirement): SystemCheckRes
     installed: false
   };
 
+  // First try the standard which approach
+  let commandPath = findCommandInPath(requirement.command);
+  
+  // If not found in PATH, try PostgreSQL-specific locations
+  if (!commandPath && (requirement.command === 'postgres' || requirement.command === 'initdb')) {
+    commandPath = findPostgreSQLCommand(requirement.command);
+  }
+
+  if (!commandPath) {
+    result.error = `Command '${requirement.command}' not found in PATH or common PostgreSQL locations`;
+    return result;
+  }
+
+  result.installed = true;
+
+  // Get version information
   try {
-    // Check if command exists
-    const whichResult = execSync(`which ${requirement.command}`, { 
-      encoding: 'utf8', 
-      stdio: 'pipe' 
-    }).trim();
-    
-    if (!whichResult) {
-      result.error = `Command '${requirement.command}' not found`;
-      return result;
+    const version = getCommandVersion(requirement.command, commandPath);
+    result.version = version;
+
+    // Check minimum version if specified
+    if (requirement.minVersion && version) {
+      result.satisfiesMinVersion = compareVersions(version, requirement.minVersion) >= 0;
     }
-
-    result.installed = true;
-
-    // Get version information
-    try {
-      const version = getCommandVersion(requirement.command);
-      result.version = version;
-
-      // Check minimum version if specified
-      if (requirement.minVersion && version) {
-        result.satisfiesMinVersion = compareVersions(version, requirement.minVersion) >= 0;
-      }
-    } catch (versionError) {
-      result.error = `Could not determine version: ${versionError.message}`;
-    }
-
-  } catch (error) {
-    result.error = `Command '${requirement.command}' not found in PATH`;
+  } catch (versionError) {
+    result.error = `Could not determine version: ${versionError.message}`;
   }
 
   return result;
 }
 
-export function getCommandVersion(command: string): string | null {
+function findCommandInPath(command: string): string | null {
+  try {
+    const whichResult = execSync(`which ${command}`, { 
+      encoding: 'utf8', 
+      stdio: 'pipe' 
+    }).trim();
+    
+    return whichResult || null;
+  } catch (error) {
+    return null;
+  }
+}
+
+function findPostgreSQLCommand(command: string): string | null {
+  // Common PostgreSQL installation paths
+  const commonPaths = [
+    // Ubuntu/Debian style
+    '/usr/lib/postgresql/15/bin',
+    '/usr/lib/postgresql/14/bin',
+    '/usr/lib/postgresql/13/bin',
+    '/usr/lib/postgresql/12/bin',
+    // RHEL/CentOS style
+    '/usr/pgsql-15/bin',
+    '/usr/pgsql-14/bin',
+    '/usr/pgsql-13/bin',
+    '/usr/pgsql-12/bin',
+    // Alternative locations
+    '/usr/local/pgsql/bin',
+    '/opt/postgresql/bin',
+    '/usr/bin'
+  ];
+
+  for (const path of commonPaths) {
+    const fullPath = `${path}/${command}`;
+    if (existsSync(fullPath)) {
+      try {
+        // Test if the binary is executable
+        execSync(`test -x "${fullPath}"`, { stdio: 'pipe' });
+        return fullPath;
+      } catch {
+        // Binary exists but not executable
+        continue;
+      }
+    }
+  }
+
+  // Try to find PostgreSQL installation using systemctl or service command
+  if (command === 'postgres') {
+    return findPostgreSQLServerBinary();
+  }
+
+  return null;
+}
+
+function findPostgreSQLServerBinary(): string | null {
+  try {
+    // Try to find PostgreSQL service and extract binary path
+    const systemctlResult = execSync('systemctl show postgresql --property=ExecStart 2>/dev/null || systemctl show postgresql* --property=ExecStart 2>/dev/null | head -1', {
+      encoding: 'utf8',
+      stdio: 'pipe'
+    }).trim();
+
+    if (systemctlResult && systemctlResult.includes('ExecStart=')) {
+      const execStart = systemctlResult.split('ExecStart=')[1];
+      if (execStart) {
+        // Extract binary path from systemctl output
+        const binaryMatch = execStart.match(/([^\s]+postgres[^\s]*)/);
+        if (binaryMatch && existsSync(binaryMatch[1])) {
+          return binaryMatch[1];
+        }
+      }
+    }
+  } catch {
+    // systemctl failed, continue with other methods
+  }
+
+  try {
+    // Try using ps to find running postgres processes
+    const psResult = execSync('ps aux | grep "postgres.*-D" | grep -v grep | head -1', {
+      encoding: 'utf8',
+      stdio: 'pipe'
+    }).trim();
+
+    if (psResult) {
+      const processPath = psResult.split(/\s+/)[10]; // Binary path is typically the 11th field
+      if (processPath && processPath.includes('postgres') && existsSync(processPath)) {
+        return processPath;
+      }
+    }
+  } catch {
+    // ps failed, continue
+  }
+
+  return null;
+}
+
+export function getCommandVersion(command: string, commandPath?: string): string | null {
   try {
     let versionOutput: string;
+    const cmdToRun = commandPath || command;
     
     switch (command) {
       case 'postgres':
-        versionOutput = execSync('postgres --version', { encoding: 'utf8', stdio: 'pipe' });
+        versionOutput = execSync(`"${cmdToRun}" --version`, { encoding: 'utf8', stdio: 'pipe' });
         break;
       case 'psql':
-        versionOutput = execSync('psql --version', { encoding: 'utf8', stdio: 'pipe' });
+        versionOutput = execSync(`"${cmdToRun}" --version`, { encoding: 'utf8', stdio: 'pipe' });
         break;
       case 'pg_dump':
-        versionOutput = execSync('pg_dump --version', { encoding: 'utf8', stdio: 'pipe' });
+        versionOutput = execSync(`"${cmdToRun}" --version`, { encoding: 'utf8', stdio: 'pipe' });
         break;
       case 'pg_restore':
-        versionOutput = execSync('pg_restore --version', { encoding: 'utf8', stdio: 'pipe' });
+        versionOutput = execSync(`"${cmdToRun}" --version`, { encoding: 'utf8', stdio: 'pipe' });
         break;
       case 'initdb':
-        versionOutput = execSync('initdb --version', { encoding: 'utf8', stdio: 'pipe' });
+        versionOutput = execSync(`"${cmdToRun}" --version`, { encoding: 'utf8', stdio: 'pipe' });
         break;
       default:
         return null;
@@ -154,10 +248,11 @@ export function checkPostgreSQLPackages(): { postgresql: boolean; postgresqlCont
     // Check if we're on a Debian/Ubuntu system
     if (existsSync('/usr/bin/dpkg')) {
       try {
-        execSync('dpkg -l postgresql* | grep "^ii"', { stdio: 'pipe' });
-        result.postgresql = true;
+        const output = execSync('dpkg -l postgresql* | grep "^ii"', { encoding: 'utf8', stdio: 'pipe' });
+        result.postgresql = output.includes('postgresql') && (output.includes('postgresql-') || output.includes('postgresql\t'));
       } catch {
-        // PostgreSQL package not installed
+        // PostgreSQL package not installed via dpkg, but check for manual installations
+        result.postgresql = checkManualPostgreSQLInstallation();
       }
 
       try {
@@ -173,7 +268,8 @@ export function checkPostgreSQLPackages(): { postgresql: boolean; postgresqlCont
         execSync('rpm -qa | grep postgresql-server', { stdio: 'pipe' });
         result.postgresql = true;
       } catch {
-        // PostgreSQL package not installed
+        // PostgreSQL package not installed via rpm, but check for manual installations
+        result.postgresql = checkManualPostgreSQLInstallation();
       }
 
       try {
@@ -182,12 +278,50 @@ export function checkPostgreSQLPackages(): { postgresql: boolean; postgresqlCont
       } catch {
         // PostgreSQL contrib not installed
       }
+    } else {
+      // No package manager detected, check for manual installation
+      result.postgresql = checkManualPostgreSQLInstallation();
     }
   } catch (error) {
-    // Error checking packages
+    // Error checking packages, try manual detection
+    result.postgresql = checkManualPostgreSQLInstallation();
   }
 
   return result;
+}
+
+function checkManualPostgreSQLInstallation(): boolean {
+  // Check common PostgreSQL installation directories
+  const commonDataDirs = [
+    '/var/lib/postgresql',
+    '/usr/local/var/postgres',
+    '/opt/postgresql',
+    '/var/lib/pgsql'
+  ];
+
+  for (const dir of commonDataDirs) {
+    if (existsSync(dir)) {
+      return true;
+    }
+  }
+
+  // Check if PostgreSQL service exists
+  try {
+    execSync('systemctl list-unit-files | grep postgresql', { stdio: 'pipe' });
+    return true;
+  } catch {
+    // No systemctl or no postgresql service
+  }
+
+  // Check for running PostgreSQL processes
+  try {
+    execSync('pgrep postgres', { stdio: 'pipe' });
+    return true;
+  } catch {
+    // No running postgres processes
+  }
+
+  return false;
 }
 
 export function getInstallationInstructions(): {
@@ -268,13 +402,28 @@ export function validateSystemForPgForge(): {
     }
   }
 
-  // Check PostgreSQL packages
+  // Check PostgreSQL packages and provide better guidance
   const packages = checkPostgreSQLPackages();
   if (!packages.postgresql) {
-    result.warnings.push('PostgreSQL package not detected via package manager (may be installed manually)');
+    // Only warn if we also can't find the binaries
+    const serverCheck = checks.find(c => c.requirement.command === 'postgres');
+    const initdbCheck = checks.find(c => c.requirement.command === 'initdb');
+    
+    if (!serverCheck?.installed || !initdbCheck?.installed) {
+      result.warnings.push('PostgreSQL server installation not fully detected. Consider adding PostgreSQL bin directory to PATH if installed.');
+    }
   }
   if (!packages.postgresqlContrib) {
     result.warnings.push('PostgreSQL contrib package not detected via package manager');
+  }
+
+  // Add helpful PATH guidance if server components are missing
+  const missingServerComponents = checks.filter(c => 
+    !c.installed && (c.requirement.command === 'postgres' || c.requirement.command === 'initdb')
+  );
+  
+  if (missingServerComponents.length > 0) {
+    result.warnings.push('If PostgreSQL is installed, try adding its bin directory to your PATH (e.g., export PATH="/usr/lib/postgresql/15/bin:$PATH")');
   }
 
   return result;


### PR DESCRIPTION
Fixes #7 - More system resiliency

Improves PostgreSQL component detection by:
- Adding enhanced command detection for common installation paths
- Implementing service-based detection using systemctl and process information
- Supporting Ubuntu/Debian, RHEL/CentOS, and manual installations
- Providing helpful PATH guidance when server components are missing

Generated with [Claude Code](https://claude.ai/code)