### PR TITLE
fix: replace corrupted Cyrillic character in test assertion

### DIFF
--- a/src/utils/validation.test.ts
+++ b/src/utils/validation.test.ts
@@ -108,7 +108,7 @@ describe('Encoding Validation', () => {
     expect(isValidEncoding('UTF8')).toBe(true);
     expect(isValidEncoding('utf8')).toBe(true);
     expect(isValidEncoding('UTF-8')).toBe(true);
-    expect(isValidEncoding('LATIN1')).toBе(true);
+    expect(isValidEncoding('LATIN1')).toBe(true);
     expect(isValidEncoding('SQL_ASCII')).toBe(true);
     expect(isValidEncoding('WIN1252')).toBe(true);
   });


### PR DESCRIPTION
Fixes test failure in `src/utils/validation.test.ts` caused by corrupted toBe assertion on line 111.

The test had a Cyrillic 'е' character instead of English 'e' in `toBe`, causing TypeError during test execution.

Fixes #13

Generated with [Claude Code](https://claude.ai/code)