### PR TITLE
fix: resolve PostgreSQL version mismatch between check and create commands

### DIFF
--- a/src/utils/system.ts
+++ b/src/utils/system.ts
@@ -92,7 +92,7 @@ export function checkRequirement(requirement: SystemRequirement): SystemCheckRes
   return result;
 }
 
-function findCommandInPath(command: string): string | null {
+export function findCommandInPath(command: string): string | null {
   try {
     const whichResult = execSync(`which ${command}`, { 
       encoding: 'utf8', 


### PR DESCRIPTION
Fixes #14

This PR resolves the PostgreSQL version detection issue where `pgforge check` successfully finds PostgreSQL 15.13 but `pgforge create` fails looking for version 15.3 binaries.

## Changes
- Add dynamic PostgreSQL version detection in ConfigManager
- Export findCommandInPath function for reuse across modules
- Enhance binary lookup with flexible path patterns
- Add fallback to `which` command for improved compatibility
- Replace hardcoded default version with detected system version

Generated with [Claude Code](https://claude.ai/code)