### PR TITLE
fix: resolve TypeScript compilation errors

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -76,7 +76,7 @@ program
       console.log(chalk.gray(`  View details: ${chalk.white('pgforge show ' + config.metadata.name)}`));
       
     } catch (error) {
-      spinner.fail(`Failed to create instance: ${error.message}`);
+      spinner.fail(`Failed to create instance: ${error instanceof Error ? error.message : String(error)}`);
       process.exit(1);
     }
   });
@@ -112,7 +112,7 @@ program
       }
       
     } catch (error) {
-      spinner.fail(`Failed to list instances: ${error.message}`);
+      spinner.fail(`Failed to list instances: ${error instanceof Error ? error.message : String(error)}`);
       process.exit(1);
     }
   });
@@ -136,7 +136,7 @@ program
       }
       
     } catch (error) {
-      spinner.fail(`Failed to start instance: ${error.message}`);
+      spinner.fail(`Failed to start instance: ${error instanceof Error ? error.message : String(error)}`);
       process.exit(1);
     }
   });
@@ -153,7 +153,7 @@ program
       spinner.succeed(`Instance '${name}' stopped successfully`);
       
     } catch (error) {
-      spinner.fail(`Failed to stop instance: ${error.message}`);
+      spinner.fail(`Failed to stop instance: ${error instanceof Error ? error.message : String(error)}`);
       process.exit(1);
     }
   });
@@ -170,7 +170,7 @@ program
       spinner.succeed(`Instance '${name}' restarted successfully`);
       
     } catch (error) {
-      spinner.fail(`Failed to restart instance: ${error.message}`);
+      spinner.fail(`Failed to restart instance: ${error instanceof Error ? error.message : String(error)}`);
       process.exit(1);
     }
   });
@@ -195,7 +195,7 @@ program
       displayInstanceDetails(config);
       
     } catch (error) {
-      spinner.fail(`Failed to show instance details: ${error.message}`);
+      spinner.fail(`Failed to show instance details: ${error instanceof Error ? error.message : String(error)}`);
       process.exit(1);
     }
   });
@@ -215,7 +215,7 @@ program
       spinner.succeed(`Instance '${name}' removed successfully`);
       
     } catch (error) {
-      spinner.fail(`Failed to remove instance: ${error.message}`);
+      spinner.fail(`Failed to remove instance: ${error instanceof Error ? error.message : String(error)}`);
       process.exit(1);
     }
   });
@@ -240,7 +240,7 @@ program
         displayInstanceDetails(config);
         
       } catch (error) {
-        spinner.fail(`Failed to get status: ${error.message}`);
+        spinner.fail(`Failed to get status: ${error instanceof Error ? error.message : String(error)}`);
         process.exit(1);
       }
     } else {
@@ -253,7 +253,7 @@ program
           displayInstanceTable(instances);
         }
       } catch (error) {
-        console.log(chalk.red(`Failed to load instances: ${error.message}`));
+        console.log(chalk.red(`Failed to load instances: ${error instanceof Error ? error.message : String(error)}`));
       }
     }
   });
@@ -297,7 +297,7 @@ program
       }
       
     } catch (error) {
-      console.log(chalk.red(`Failed to get connection info: ${error.message}`));
+      console.log(chalk.red(`Failed to get connection info: ${error instanceof Error ? error.message : String(error)}`));
       process.exit(1);
     }
   });
@@ -347,7 +347,7 @@ program
       console.log(chalk.gray(`  List instances: ${chalk.white('pgforge list')}`));
       
     } catch (error) {
-      spinner.fail(`Failed to initialize: ${error.message}`);
+      spinner.fail(`Failed to initialize: ${error instanceof Error ? error.message : String(error)}`);
       process.exit(1);
     }
   });
@@ -450,7 +450,7 @@ program
       }
       
     } catch (error) {
-      spinner.fail(`Failed to check system requirements: ${error.message}`);
+      spinner.fail(`Failed to check system requirements: ${error instanceof Error ? error.message : String(error)}`);
       process.exit(1);
     }
   });

--- a/src/config/manager.ts
+++ b/src/config/manager.ts
@@ -289,6 +289,8 @@ export class ConfigManager {
         },
         testing: {
           network: {
+            port: 5433,
+            bindAddress: '127.0.0.1',
             maxConnections: 50,
           },
           backup: {

--- a/src/utils/system.ts
+++ b/src/utils/system.ts
@@ -79,14 +79,14 @@ export function checkRequirement(requirement: SystemRequirement): SystemCheckRes
   // Get version information
   try {
     const version = getCommandVersion(requirement.command, commandPath);
-    result.version = version;
+    result.version = version ?? undefined;
 
     // Check minimum version if specified
     if (requirement.minVersion && version) {
       result.satisfiesMinVersion = compareVersions(version, requirement.minVersion) >= 0;
     }
   } catch (versionError) {
-    result.error = `Could not determine version: ${versionError.message}`;
+    result.error = `Could not determine version: ${versionError instanceof Error ? versionError.message : String(versionError)}`;
   }
 
   return result;
@@ -159,7 +159,7 @@ function findPostgreSQLServerBinary(): string | null {
       if (execStart) {
         // Extract binary path from systemctl output
         const binaryMatch = execStart.match(/([^\s]+postgres[^\s]*)/);
-        if (binaryMatch && existsSync(binaryMatch[1])) {
+        if (binaryMatch && binaryMatch[1] && existsSync(binaryMatch[1])) {
           return binaryMatch[1];
         }
       }
@@ -215,7 +215,7 @@ export function getCommandVersion(command: string, commandPath?: string): string
 
     // Extract version number from output
     const versionMatch = versionOutput.match(/(\d+\.\d+(?:\.\d+)?)/);
-    return versionMatch ? versionMatch[1] : null;
+    return versionMatch && versionMatch[1] ? versionMatch[1] : null;
   } catch (error) {
     return null;
   }

--- a/src/utils/validation.test.ts
+++ b/src/utils/validation.test.ts
@@ -234,7 +234,7 @@ describe('Port Availability Validation', () => {
   test('should detect port conflicts', () => {
     const errors = validatePortAvailable(5432, existingInstances);
     expect(errors.length).toBeGreaterThan(0);
-    expect(errors[0].field).toBe('spec.network.port');
+    expect(errors[0]?.field).toBe('spec.network.port');
   });
 
   test('should allow available ports', () => {


### PR DESCRIPTION
Fixes #17

Resolves all TypeScript compilation errors found when running `bun run tsc --noEmit`:

- Fix TS18046 errors by adding proper error type checking in catch blocks
- Fix TS2739 error by adding missing network properties to testing template
- Fix TS2322/TS2345 errors by converting null to undefined and adding proper type checks
- Fix TS2532 error by using optional chaining in test assertions

Generated with [Claude Code](https://claude.ai/code)