### PR TITLE
feat: use user local directories instead of system directories

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -8,7 +8,7 @@ import { InstanceManager } from './src/instance/manager.js';
 import { ConfigManager } from './src/config/manager.js';
 import { displayInstanceTable, displayInstanceDetails, displaySystemStatus, displayConnectionInfo, formatAsJson, formatAsYaml } from './src/utils/display.js';
 import { validateInstanceConfig, isValidInstanceName } from './src/utils/validation.js';
-import { validateSystemForPgForge, checkSystemRequirements, getInstallationInstructions } from './src/utils/system.js';
+import { validateSystemForPgForge, checkSystemRequirements, getInstallationInstructions, getUserDirectories } from './src/utils/system.js';
 
 const program = new Command();
 const instanceManager = new InstanceManager();
@@ -316,13 +316,14 @@ program
       try {
         await configManager.getGlobalConfig();
       } catch {
+        const userDirs = getUserDirectories();
         const defaultConfig = {
           apiVersion: 'v1',
           kind: 'Configuration',
           global: {
-            dataRoot: '/var/lib/postgresql/pgforge',
-            logRoot: '/var/log/postgresql/pgforge', 
-            backupRoot: '/var/backups/postgresql/pgforge',
+            dataRoot: userDirs.dataRoot,
+            logRoot: userDirs.logRoot, 
+            backupRoot: userDirs.backupRoot,
             postgresql: {
               packageManager: 'apt' as const,
               versions: ['15.3', '14.8', '13.11'],

--- a/src/config/manager.ts
+++ b/src/config/manager.ts
@@ -5,7 +5,7 @@ import { join, dirname } from 'path';
 import { homedir } from 'os';
 import * as YAML from 'yaml';
 import type { PostgreSQLInstanceConfig, GlobalConfig, InstanceTemplate } from './types.js';
-import { getCommandVersion, findCommandInPath } from '../utils/system.js';
+import { getCommandVersion, findCommandInPath, getUserDirectories } from '../utils/system.js';
 
 export class ConfigManager {
   private configDir: string;
@@ -236,13 +236,15 @@ export class ConfigManager {
   }
 
   private getDefaultGlobalConfig(): GlobalConfig {
+    const userDirs = getUserDirectories();
+    
     return {
       apiVersion: 'v1',
       kind: 'Configuration',
       global: {
-        dataRoot: '/var/lib/postgresql/pgforge',
-        logRoot: '/var/log/postgresql/pgforge',
-        backupRoot: '/var/backups/postgresql/pgforge',
+        dataRoot: userDirs.dataRoot,
+        logRoot: userDirs.logRoot,
+        backupRoot: userDirs.backupRoot,
         postgresql: {
           packageManager: 'apt',
           versions: ['15.3', '14.8', '13.11'],

--- a/src/utils/system.test.ts
+++ b/src/utils/system.test.ts
@@ -1,5 +1,7 @@
 import { describe, test, expect } from 'bun:test';
-import { SYSTEM_REQUIREMENTS } from './system.js';
+import { SYSTEM_REQUIREMENTS, getUserDirectories } from './system.js';
+import { homedir } from 'os';
+import { join } from 'path';
 
 describe('System Requirements', () => {
   test('should define required PostgreSQL components', () => {
@@ -38,5 +40,50 @@ describe('System Requirements', () => {
     const postgresReq = SYSTEM_REQUIREMENTS.find(req => req.name === 'PostgreSQL Server');
     expect(postgresReq?.minVersion).toBeTruthy();
     expect(postgresReq?.minVersion).toBe('15.3');
+  });
+});
+
+describe('User Directories', () => {
+  test('should return user-local directories following XDG spec', () => {
+    const dirs = getUserDirectories();
+    
+    // Test that all required directory properties are present
+    expect(dirs.dataRoot).toBeDefined();
+    expect(dirs.logRoot).toBeDefined(); 
+    expect(dirs.backupRoot).toBeDefined();
+    
+    // Test that directories are under user home (when XDG_DATA_HOME is not set)
+    const originalXdgDataHome = process.env.XDG_DATA_HOME;
+    delete process.env.XDG_DATA_HOME;
+    
+    const dirsDefault = getUserDirectories();
+    expect(dirsDefault.dataRoot).toContain(homedir());
+    expect(dirsDefault.dataRoot).toContain('.local/share/pgforge');
+    expect(dirsDefault.logRoot).toBe(join(dirsDefault.dataRoot, 'logs'));
+    expect(dirsDefault.backupRoot).toBe(join(dirsDefault.dataRoot, 'backups'));
+    
+    // Restore original XDG_DATA_HOME
+    if (originalXdgDataHome) {
+      process.env.XDG_DATA_HOME = originalXdgDataHome;
+    }
+  });
+  
+  test('should respect XDG_DATA_HOME environment variable', () => {
+    const originalXdgDataHome = process.env.XDG_DATA_HOME;
+    const testXdgDataHome = '/tmp/test-xdg';
+    
+    process.env.XDG_DATA_HOME = testXdgDataHome;
+    
+    const dirs = getUserDirectories();
+    expect(dirs.dataRoot).toBe(join(testXdgDataHome, 'pgforge'));
+    expect(dirs.logRoot).toBe(join(testXdgDataHome, 'pgforge', 'logs'));
+    expect(dirs.backupRoot).toBe(join(testXdgDataHome, 'pgforge', 'backups'));
+    
+    // Restore original XDG_DATA_HOME
+    if (originalXdgDataHome) {
+      process.env.XDG_DATA_HOME = originalXdgDataHome;
+    } else {
+      delete process.env.XDG_DATA_HOME;
+    }
   });
 });

--- a/src/utils/system.ts
+++ b/src/utils/system.ts
@@ -1,5 +1,7 @@
 import { execSync } from 'child_process';
 import { existsSync } from 'fs';
+import { homedir } from 'os';
+import { join } from 'path';
 
 export interface SystemRequirement {
   name: string;
@@ -427,4 +429,25 @@ export function validateSystemForPgForge(): {
   }
 
   return result;
+}
+
+/**
+ * Get user-local directories following XDG Base Directory specification.
+ * This avoids permission issues with system directories like /var/lib/postgresql.
+ */
+export function getUserDirectories(): {
+  dataRoot: string;
+  logRoot: string;
+  backupRoot: string;
+} {
+  // Follow XDG Base Directory specification
+  // XDG_DATA_HOME defaults to ~/.local/share
+  const xdgDataHome = process.env.XDG_DATA_HOME || join(homedir(), '.local', 'share');
+  const pgforgeDataDir = join(xdgDataHome, 'pgforge');
+  
+  return {
+    dataRoot: pgforgeDataDir,
+    logRoot: join(pgforgeDataDir, 'logs'), 
+    backupRoot: join(pgforgeDataDir, 'backups'),
+  };
 }


### PR DESCRIPTION
Fixes permission issues when running PostgreSQL under user account by using XDG Base Directory specification.

## Changes
- Add getUserDirectories() function following XDG Base Directory specification
- Update default configuration to use ~/.local/share/pgforge for data
- Update init command to use user-accessible directories
- Add comprehensive tests for user directory functionality

Resolves #19

🤖 Generated with [Claude Code](https://claude.ai/code)