### PR TITLE
fix: disable SSL by default to prevent startup failures

### DIFF
--- a/src/config/manager.ts
+++ b/src/config/manager.ts
@@ -202,7 +202,7 @@ export class ConfigManager {
         },
         security: {
           ssl: {
-            enabled: true,
+            enabled: false,
           },
           authentication: {
             method: 'md5',


### PR DESCRIPTION
PostgreSQL instances were failing to start because SSL was enabled by default but no certificates were provided. This change disables SSL by default while still allowing it to be enabled via templates (production) or manual configuration.

Fixes #20

Generated with [Claude Code](https://claude.ai/code)