### PR TITLE
fix: configure socket directory for temporary PostgreSQL instance

### DIFF
--- a/src/instance/manager.ts
+++ b/src/instance/manager.ts
@@ -231,11 +231,13 @@ export class InstanceManager {
     console.log(`PostgreSQL binary: ${postgresPath}`);
     console.log(`Data directory: ${config.spec.storage.dataDirectory}`);
     
-    // Start PostgreSQL in background
+    // Start PostgreSQL in background with user-local socket directory
+    const socketDirectory = join(config.spec.storage.dataDirectory, 'sockets');
     const tempProcess = spawn(postgresPath, [
       '-D', config.spec.storage.dataDirectory,
       '-p', config.spec.network.port.toString(),
       '-c', 'listen_addresses=127.0.0.1',
+      '-c', `unix_socket_directories=${socketDirectory}`,
     ], {
       detached: false,
       stdio: ['ignore', 'pipe', 'pipe'], // Capture stdout and stderr for debugging


### PR DESCRIPTION
Fixes PostgreSQL lock file permission issues by configuring the unix_socket_directories parameter when starting temporary PostgreSQL instances.

## Changes
- Add unix_socket_directories parameter when starting temporary PostgreSQL
- Prevents permission denied errors by using user-local socket directory
- Fixes lock file creation issues in /var/run/postgresql/

Resolves #41

Generated with [Claude Code](https://claude.ai/code)