### PR TITLE
fix: PostgreSQL TCP/IP connection issue in instance creation

### DIFF
--- a/src/instance/manager.ts
+++ b/src/instance/manager.ts
@@ -236,7 +236,7 @@ export class InstanceManager {
     const tempProcess = spawn(postgresPath, [
       '-D', config.spec.storage.dataDirectory,
       '-p', config.spec.network.port.toString(),
-      '-c', 'listen_addresses=127.0.0.1',
+      '-c', `listen_addresses=${config.spec.network.bindAddress}`,
       '-c', `unix_socket_directories=${socketDirectory}`,
     ], {
       detached: false,


### PR DESCRIPTION
Fixes issue where PostgreSQL instances could not accept TCP/IP connections during creation.

The temporary PostgreSQL instance during database creation was hardcoded to listen only on 127.0.0.1, causing connection failures when the final configuration expected to bind to 0.0.0.0. This change ensures consistency between temporary and final instance configurations.

Fixes #-43

Generated with [Claude Code](https://claude.ai/code)