### PR TITLE
fix: add --username=postgres to initdb command to ensure postgres role exists

### DIFF
--- a/src/instance/manager.ts
+++ b/src/instance/manager.ts
@@ -449,6 +449,7 @@ export class InstanceManager {
     const command = [
       initdbPath,
       '-D', config.spec.storage.dataDirectory,
+      '--username=postgres',
       '--auth-local=trust',
       '--auth-host=md5',
       `--encoding=${config.spec.database.encoding}`,


### PR DESCRIPTION
This PR fixes the PostgreSQL instance creation issue where the "postgres" role didn't exist.

The initdb command was creating a superuser with the system username instead of 'postgres', causing connection failures. Adding --username=postgres explicitly creates the expected postgres superuser role during initialization.

Fixes #48

Generated with [Claude Code](https://claude.ai/code)