### PR TITLE
fix: pgforge service autostart functionality

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -127,7 +127,7 @@ program
     const spinner = ora(`Starting instance '${name}'...`).start();
     
     try {
-      await instanceManager.startInstance(name);
+      await instanceManager.startInstanceWithService(name);
       spinner.succeed(`Instance '${name}' started successfully`);
       
       const config = await instanceManager.getInstanceStatus(name);
@@ -154,7 +154,7 @@ program
     const spinner = ora(`Stopping instance '${name}'...`).start();
     
     try {
-      await instanceManager.stopInstance(name);
+      await instanceManager.stopInstanceWithService(name);
       spinner.succeed(`Instance '${name}' stopped successfully`);
       
     } catch (error) {

--- a/src/instance/manager.ts
+++ b/src/instance/manager.ts
@@ -150,12 +150,12 @@ export class InstanceManager {
     }
 
     if (config.status?.state === 'running') {
-      await this.stopInstance(name);
+      await this.stopInstanceWithService(name);
       // Wait a moment for cleanup
       await new Promise(resolve => setTimeout(resolve, 2000));
     }
 
-    await this.startInstance(name);
+    await this.startInstanceWithService(name);
   }
 
   async getInstanceStatus(name: string): Promise<PostgreSQLInstanceConfig | null> {


### PR DESCRIPTION
Fixes the pgforge service autostart issue where enabled services wouldn't start after system restart.

## Changes
- Fixed systemd service file generation to use Type=notify instead of Type=forking
- Added missing PostgreSQL options (socket directory, port)
- Added proper ExecStop command and timeouts
- Updated CLI commands to use service-aware methods
- Made restart command service-aware

## Testing
1. Enable service: `pgforge enable-service <instance>`
2. Check status: `pgforge service-status <instance>`
3. Restart system to verify autostart works

Fixes #52

Generated with [Claude Code](https://claude.ai/code)